### PR TITLE
Fix GetBpp() + uncompressed_size for packed pixel formats

### DIFF
--- a/include/BglData.h
+++ b/include/BglData.h
@@ -3539,12 +3539,16 @@ public:
 private:
     std::unique_ptr<uint8_t[]> DecompressData(ERasterCompressionType compression_type, const uint8_t* compressed_data,
         int compressed_size, int uncompressed_size) const;
+    // Bytes per decoded output pixel for each TRQ1 data type. Used as the
+    // output pixel stride by the PTC codec (see DecompressPtc) and by the
+    // CalculateLength helper. Must match the actual on-disk / in-memory
+    // stride of a single pixel, NOT the PTC codec's internal block-element
+    // size which coincides for most types.
     int GetBpp() const
     {
         switch (GetDataType())
         {
         case ERasterDataType::PopulationDensity:
-        case ERasterDataType::TerrainIndex:
         case ERasterDataType::LandClass:
         case ERasterDataType::Region:
         case ERasterDataType::Season:
@@ -3554,6 +3558,7 @@ private:
         case ERasterDataType::Elevation:
         case ERasterDataType::ModifiedElevation:
         case ERasterDataType::Photo:
+        case ERasterDataType::TerrainIndex:
             return 2;
         case ERasterDataType::PhotoFlight:
             return 4;

--- a/src/BglData.cpp
+++ b/src/BglData.cpp
@@ -8132,10 +8132,11 @@ bool flightsimlib::io::CTerrainRasterQuad1::DecompressRaster(
         return false;
     }
 
-    // `bit_depth` from GetImageFormatForType is the TOTAL pixel width, not
-    // per-channel. Multiplying by `num_channels` would over-size the
-    // buffer for packed formats (Photo is ARGB1555 = 16 bits total across
-    // 4 channels). Use GetBpp() which already returns bytes per pixel.
+    // `bit_depth` from GetImageFormatForType is the TOTAL pixel width,
+    // not per-channel (see the comment on that function). Do NOT
+    // multiply by `num_channels`; that over-sizes the buffer 4x for
+    // packed types like Photo (ARGB1555) and PhotoFlight. GetBpp()
+    // already reports the correct bytes-per-pixel value.
     const int bytes_per_pixel = GetBpp();
     const int uncompressed_size = static_cast<int>(bytes_per_pixel * header.Rows * header.Cols);
     if (uncompressed_size <= 0)
@@ -8167,15 +8168,11 @@ auto flightsimlib::io::ConvertRasterToRgba(const SRasterImage& image, std::vecto
     }
 
     const size_t pixel_count = static_cast<size_t>(image.Width) * static_cast<size_t>(image.Height);
-    // Minimum bytes required: Channels * BitDepth/8 for formats where
-    // BitDepth is per-channel (8, 32), or just BitDepth/8 for Photo where
-    // BitDepth is total. We do the permissive union check here and let
-    // each per-format branch below verify its own specific size.
-    const size_t min_bytes_per_pixel =
-        (image.DataType == ERasterDataType::Photo)
-            ? static_cast<size_t>(image.BitDepth / 8)
-            : static_cast<size_t>(image.Channels) * static_cast<size_t>(image.BitDepth / 8);
-    if (image.DataSize < pixel_count * min_bytes_per_pixel)
+    // `BitDepth` is the TOTAL pixel bit width for every supported data
+    // type (see GetImageFormatForType). Do NOT multiply by Channels.
+    // This mirrors CTerrainRasterQuad1::GetBpp() on the decode side.
+    const size_t bytes_per_pixel = static_cast<size_t>(image.BitDepth / 8);
+    if (image.DataSize < pixel_count * bytes_per_pixel)
     {
         return false;
     }


### PR DESCRIPTION
Follow-up to #5. That PR exposed two interrelated latent bugs in the bytes-per-pixel story that together make `TerrainIndex` decode short-read under current master; this PR fixes both at the source.

## 1. `GetBpp()` for TerrainIndex

Every TRQ1 `TerrainIndex` tile is a **16-bit bitmask per pixel** encoding which terrain datatypes (Photo, Elevation, LandClass, ...) are available on that QMID. On-disk stride is 2 bytes, but `GetBpp()` was reporting 1 — latent bugs in every caller:

- **`DecompressPtc`** uses `bpp` as the output pixel stride: `idx_denorm += bpp` per pixel, `p_dest` sized as `bpp × 256 × 256`, `StrideBytes = bpp × 0x100`. If PTC ever decodes a TerrainIndex tile it writes 16-bit values with a 1-byte stride → overlapping writes / undefined behavior. Rarely exercised in practice because TerrainIndex typically compresses with BitPackLz1 instead of PTC, but a real bug.
- **`CalculateLength()`** computed `GetBpp() × Cols × Rows = 1024` for a 32×32 TerrainIndex tile when the actual uncompressed length is 2048. The method is currently uncalled; fixing `GetBpp()` makes it accurate and safe to grow into.
- **`CTerrainRasterQuad1::DecompressRaster`** inherited the same wrong stride after #5 when we routed it through `GetBpp()`. That's how newdawn's TerrainIndex spatial-content ingest started short-reading all 15 tiles the moment it tried to decode them.

Moved `TerrainIndex` into the `return 2` group alongside `Elevation` / `Photo`. Added a comment on the function making the semantics explicit (\"bytes per decoded output pixel — NOT the PTC block-element size\") so future additions don't regress it.

Audit of remaining `return 1` cases (`PopulationDensity`, `LandClass`, `Region`, `Season`, `WaterClass`): all genuinely 8-bit-per-pixel per bgldec's `BPPForType`, so they stay put.

## 2. `DecompressRaster` + `ConvertRasterToRgba` uncompressed-size math

Pre-#5 code computed `(bit_depth / 8) × num_channels`, which over-sized the buffer 4× for packed types like Photo (ARGB1555 = 16 bits total across 4 channels). #5 switched `DecompressRaster` to `GetBpp()` — correct for Photo but wrong for TerrainIndex because of bug #1. With `GetBpp()` fixed, `DecompressRaster` continues using it; the comment drops the \"GetBpp disagrees for TerrainIndex\" caveat from my earlier draft because it no longer does.

`ConvertRasterToRgba`'s preliminary size check switches to `BitDepth / 8` (which is equivalent to `GetBpp()` for every supported type because `BitDepth` is the TOTAL pixel width in `GetImageFormatForType`'s convention) and loses its `DataType == Photo` special case — a band-aid against the same underlying asymmetry that now resolves cleanly.

## Breaking change

None beyond #5. `GetBpp()` is defined inline in the class header as a `private` helper, so its changed return value doesn't affect ABI.

## Test plan

- [x] `DeathValley_Elevations.bgl` (FSX-era, 100 elevation tiles + 2 TerrainIndex tiles): both groups decode. Range scan matches pre-refactor `[-83, 3367]`.
- [x] `MillenniumImage_water_blend.bgl` (P3D v6 SDK, 12 aliased photo sections + 15 TerrainIndex tiles across 15 LODs): photo pipeline (fixed in #5) and TerrainIndex spatial-content ingest (regressed after #5, restored here) now work simultaneously. All 15 TerrainIndex tiles ingest at the expected 32×32 dimensions; photo rendering unchanged.
- [ ] Spot-check a `LandClass` / `WaterClass` BGL — should be unaffected (their `GetBpp()` stays at 1, which matches the on-disk 8-bit-per-pixel stride), but worth confirming when a sample is handy.
- [ ] Spot-check a `TerrainIndex` tile that does use PTC compression — the stride fix in `DecompressPtc` is untestable against bundled samples since they use BitPackLz1, but the bug is latent and the fix is a 1-byte → 2-byte change that matches every other u16-per-pixel caller.