### PR TITLE
Add missing Linux-required standard headers

### DIFF
--- a/external/PTC/PTC.c
+++ b/external/PTC/PTC.c
@@ -4,6 +4,7 @@
 #include "PTC.h"
 
 #include <assert.h>
+#include <stdint.h>
 
 
 #pragma warning(disable: 6385)

--- a/include/BglFile.h
+++ b/include/BglFile.h
@@ -41,6 +41,7 @@
 
 #include "../external/stlab/copy_on_write.hpp"
 
+#include <cstring>
 #include <map>
 #include <memory>
 #include <string>


### PR DESCRIPTION
## Summary

- Add `#include <stdint.h>` to `external/PTC/PTC.c`
- Add `#include <cstring>` to `include/BglFile.h`

These headers are implicitly available on MSVC but required explicitly on Linux/GCC, causing build failures in dependent repos targeting Linux.

## Test plan

- [ ] Verify the library builds cleanly on Linux/GCC with no implicit declaration errors
- [ ] Confirm no regressions on Windows/MSVC build

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbvkTYPaWLc86Fyuozekdn)_